### PR TITLE
updated Ahmed Khan's comments commit with minor changes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
+  "fmt"
 )
 
 // GetSubmittedNominees is the function handler used to handle the GET request
@@ -22,6 +23,42 @@ func GetSubmittedNominees(c *gin.Context) {
 		c.String(http.StatusInternalServerError, err.Error())
 	}
 	c.JSON(http.StatusOK, result)
+}
+
+func GetComments(c *gin.Context) {
+	NomineeIDString := c.GetHeader("NomineeID")
+	NomineeID, err := strconv.Atoi(NomineeIDString)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+	}
+	result, err := psql.GetCommentsFromDB(NomineeID)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+	}
+	c.JSON(http.StatusOK, result)
+}
+func AddComment(c *gin.Context) {
+  fmt.Println("1. starting add comment")
+	useridString := c.GetHeader("user")
+	userid , err := strconv.Atoi(useridString)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+	}
+  fmt.Println("2. ")
+	NomineeIDString := c.Param("NOMID") // generate ID
+	NomineeID , err := strconv.Atoi(NomineeIDString)
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+	}
+	content := c.GetHeader("content")
+  fmt.Println("3. ")
+
+  _, err2 := psql.AddCommentDB(userid, NomineeID, content)
+	if err2 != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+	}
+  fmt.Println("4. ")
+	c.JSON(http.StatusOK, "the comment has been added")
 }
 
 // ApproveNominee is the function hanlder user to handle the POST request

--- a/api/api.go
+++ b/api/api.go
@@ -1,11 +1,11 @@
 package api
 
 import (
+	"fmt"
 	"github.com/arsidada/go-onemax/psql"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
-  "fmt"
 )
 
 // GetSubmittedNominees is the function handler used to handle the GET request
@@ -38,26 +38,26 @@ func GetComments(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 func AddComment(c *gin.Context) {
-  fmt.Println("1. starting add comment")
+	fmt.Println("1. starting add comment")
 	useridString := c.GetHeader("user")
-	userid , err := strconv.Atoi(useridString)
+	userid, err := strconv.Atoi(useridString)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 	}
-  fmt.Println("2. ")
+	fmt.Println("2. ")
 	NomineeIDString := c.Param("NOMID") // generate ID
-	NomineeID , err := strconv.Atoi(NomineeIDString)
+	NomineeID, err := strconv.Atoi(NomineeIDString)
 	if err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 	}
 	content := c.GetHeader("content")
-  fmt.Println("3. ")
+	fmt.Println("3. ")
 
-  _, err2 := psql.AddCommentDB(userid, NomineeID, content)
+	_, err2 := psql.AddCommentDB(userid, NomineeID, content)
 	if err2 != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 	}
-  fmt.Println("4. ")
+	fmt.Println("4. ")
 	c.JSON(http.StatusOK, "the comment has been added")
 }
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ func main() {
 	// Defining routes for a gin webserver
 	router := gin.Default()
 	router.GET("/submitted_nominees", api.GetSubmittedNominees)
+	router.GET("/nominee_comments", api.GetComments)
+	router.POST("/add_comment/:NOMID", api.AddComment)
 	router.POST("/approve_nominee/:ID", api.ApproveNominee)
 	router.POST("/reject_nominee/:ID", api.ApproveNominee)
 	router.Run()

--- a/main.go
+++ b/main.go
@@ -11,10 +11,16 @@ func main() {
 
 	// Defining routes for a gin webserver
 	router := gin.Default()
+
+	// Routes for Approvals API
 	router.GET("/submitted_nominees", api.GetSubmittedNominees)
-	router.GET("/nominee_comments", api.GetComments)
-	router.POST("/add_comment/:NOMID", api.AddComment)
 	router.POST("/approve_nominee/:ID", api.ApproveNominee)
 	router.POST("/reject_nominee/:ID", api.ApproveNominee)
+
+	// Routes for Comments API
+	router.GET("/comments/:NomineeID", api.GetComments)
+	router.POST("/comments/:NomineeID", api.AddComment)
+
+	// Starting up gin server
 	router.Run()
 }

--- a/psql/psql.go
+++ b/psql/psql.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"github.com/go-pg/pg"
 	"os"
+  "fmt"
 	// "github.com/go-pg/pg/orm"
 )
 
@@ -18,6 +19,16 @@ type Nomination struct {
 	Image       string
 	Duas        int
 }
+
+type Comment struct {
+	ID          int
+	Nomineeid   int
+	Userid      int
+	Content     string
+	Createdat   string
+}
+
+
 
 // Global var to hold the database object
 var db *pg.DB
@@ -54,6 +65,30 @@ func GetSubmittedNomineesFromDB() ([]Nomination, error) {
 	}
 
 	return result, nil
+}
+
+func GetCommentsFromDB(NomineeID int) ([]Comment, error) {
+	result := make([]Comment, 0)
+	err := db.Model(&result).
+		Where("nomineeid = ?", NomineeID).
+		Select()
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+func AddCommentDB(userID int, nomineeID int, content string) (int, error){
+  fmt.Println("going to add the comment ", content, " userid: ", userID, " nomineeID: ", nomineeID)
+  err := db.Insert(&Comment{
+    Userid : userID,
+    Nomineeid : nomineeID,
+    Content : content,
+  })
+  if(err != nil){
+    return -1, err
+  }
+
+  return 0, nil
 }
 
 // ApproveNomineeDB uses the ID parameter to updates a record's status value

--- a/psql/psql.go
+++ b/psql/psql.go
@@ -2,9 +2,9 @@ package psql
 
 import (
 	"crypto/tls"
+	"fmt"
 	"github.com/go-pg/pg"
 	"os"
-  "fmt"
 	// "github.com/go-pg/pg/orm"
 )
 
@@ -21,14 +21,12 @@ type Nomination struct {
 }
 
 type Comment struct {
-	ID          int
-	Nomineeid   int
-	Userid      int
-	Content     string
-	Createdat   string
+	ID        int
+	Nomineeid int
+	Userid    int
+	Content   string
+	Createdat string
 }
-
-
 
 // Global var to hold the database object
 var db *pg.DB
@@ -77,18 +75,18 @@ func GetCommentsFromDB(NomineeID int) ([]Comment, error) {
 	}
 	return result, nil
 }
-func AddCommentDB(userID int, nomineeID int, content string) (int, error){
-  fmt.Println("going to add the comment ", content, " userid: ", userID, " nomineeID: ", nomineeID)
-  err := db.Insert(&Comment{
-    Userid : userID,
-    Nomineeid : nomineeID,
-    Content : content,
-  })
-  if(err != nil){
-    return -1, err
-  }
+func AddCommentDB(userID int, nomineeID int, content string) (int, error) {
+	fmt.Println("going to add the comment ", content, " userid: ", userID, " nomineeID: ", nomineeID)
+	err := db.Insert(&Comment{
+		Userid:    userID,
+		Nomineeid: nomineeID,
+		Content:   content,
+	})
+	if err != nil {
+		return -1, err
+	}
 
-  return 0, nil
+	return 0, nil
 }
 
 // ApproveNomineeDB uses the ID parameter to updates a record's status value

--- a/psql/psql.go
+++ b/psql/psql.go
@@ -20,10 +20,11 @@ type Nomination struct {
 	Duas        int
 }
 
+// Comment is an object definition to store value from the Comment table
 type Comment struct {
 	ID        int
 	Nomineeid int
-	Userid    int
+	Username  string
 	Content   string
 	Createdat string
 }
@@ -65,30 +66,6 @@ func GetSubmittedNomineesFromDB() ([]Nomination, error) {
 	return result, nil
 }
 
-func GetCommentsFromDB(NomineeID int) ([]Comment, error) {
-	result := make([]Comment, 0)
-	err := db.Model(&result).
-		Where("nomineeid = ?", NomineeID).
-		Select()
-	if err != nil {
-		return result, err
-	}
-	return result, nil
-}
-func AddCommentDB(userID int, nomineeID int, content string) (int, error) {
-	fmt.Println("going to add the comment ", content, " userid: ", userID, " nomineeID: ", nomineeID)
-	err := db.Insert(&Comment{
-		Userid:    userID,
-		Nomineeid: nomineeID,
-		Content:   content,
-	})
-	if err != nil {
-		return -1, err
-	}
-
-	return 0, nil
-}
-
 // ApproveNomineeDB uses the ID parameter to updates a record's status value
 // from 'submitted' to 'approved'. We return a 200 if the update is successful.
 // Otherwise we return a 500 and an error
@@ -124,4 +101,32 @@ func RejectNomineeDB(ApprovalID int) (int, error) {
 		return 500, err
 	}
 	return 200, nil
+}
+
+// GetCommentsFromDB fetches all rows from the comments table for a
+// given NomineeID
+func GetCommentsFromDB(NomineeID int) ([]Comment, error) {
+	result := make([]Comment, 0)
+	err := db.Model(&result).
+		Where("nomineeid = ?", NomineeID).
+		Select()
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+// AddCommentDB add a new entry to the comments table for a
+// given NomineeID and UserID combination
+func AddCommentDB(username string, nomineeID int, content string) (int, error) {
+	fmt.Println("Adding new comment with content: ", content, " username: ", username, " nomineeID: ", nomineeID)
+	err := db.Insert(&Comment{
+		Username:  username,
+		Nomineeid: nomineeID,
+		Content:   content,
+	})
+	if err != nil {
+		return -1, err
+	}
+	return 0, nil
 }


### PR DESCRIPTION
- Fixed formatting issues with `go fmt` and `go vet -v`
- Organized code to separate approvals API stuff from comments API
- Added comments to functions
- Updated comments API names to be just `comments` for both GET and POST calls. It's more convenient to use
- Updated API to not `userid` but use `username` instead. When using `userid`, the front-end app will have to figure out who this ID is by calling the FB or Google auth API and then show the name. This is highly inefficient. Instead if we store the `username` from when the comment was made, we can just return that when a GET comments call is made
- Updated comments POST API to accept the content of the comment via Body and not via Header. Using content in headers is against REST best practices